### PR TITLE
Initial pass at MATLAB runtime

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1232,14 +1232,39 @@ detector is available under an open-source license {\em (Tentatively GPL, but we
 \item[Runtime:]\hfill
   \begin{description}
   \item[MATLAB:] {\tt https://github.com/gardner-lab/syllable-detector-matlab}
-    \marginpar{Jeff: Can you flesh this out?}
     \begin{description}
     \item[Installation:]\hfill
-      \begin{trivlist}
+      \begin{itemize}
       \item Clone the Github repository onto your computer.
-      \end{trivlist}
+      \item Usage requires MATLAB with the Data Acquisition Toolbox and the 
+      Parallel Computing Toolbox.
+      \end{itemize}
     \item[Connection:]\hfill
+      \begin{itemize}
+      \item Either connect the microphone directly into the microphone jack or through a 
+      preamp into the audio input jack. The current implementation only supports a single 
+      channel of audio.
+      \item To generate TTL signals via the audio output, use the headphone or audio output
+      jack.
+      \item To generate TTL signals via an Arduino, switch to the {\tt arduino} branch, 
+      load the MATLAB Arduino IO sketch onto the Arduino (the sketch is available in the 
+      Github repository, and provides a simple serial protocol for controlling pins). 
+      Connect the Arduino to the computer via USB. The TTL signal will be available on
+      pin 7.
+      \end{itemize}
     \item[Usage:]\hfill
+      \begin{itemize}
+      \item Switch to the directory of the repository and run {\tt nndetector\_live}. You
+      can optionally specify parameters as string/value pairs. When you run the command,
+      you will be prompted to select an input device, output device and select a ``.mat''
+      file containing the trained detector.
+      \item Note that you may need to tune the input and output buffer based on computer 
+      performance. Try decreasing the size of the buffers until you see warnings about buffer
+      under/overruns, then increase the value slightly. We usually found 2-3ms worked reliably.
+      To specify the buffer sizes, use the {\tt buffer\_size\_input} and 
+      {\tt buffer\_size\_output} parameters.
+      \item Information about the detector is logged to a file called ``detector\_status.log''.
+      \end{itemize}
     \end{description}
   \item[Swift:] {\tt https://github.com/gardner-lab/syllable-detector-swift}
     \begin{description}
@@ -1255,7 +1280,7 @@ detector is available under an open-source license {\em (Tentatively GPL, but we
       different detectors on each channel simultaneously.
       \item To generate TTL signals via the audio output, use the headphone jack. The 
       audio output must have at least the same number of channels as the input.
-      \item To generate TTL signals via an Arduino, load the MATLAB arduino IO sketch 
+      \item To generate TTL signals via an Arduino, load the MATLAB Arduino IO sketch 
       onto the Arduino (the sketch is available in the Github repository, and provides a 
       simple serial protocol for controlling pins). Connect the Arduino 
       to the computer via USB. The TTL signal for the first input will be available on 
@@ -1276,7 +1301,7 @@ detector is available under an open-source license {\em (Tentatively GPL, but we
       \begin{itemize}
       \item You can clone the Github repository and use Xcode to edit the project, if you 
       are interested in extending or modifying the functionality. To hook into either 
-      the raw input or output, look at the ``ViewControllerProcessor.swift'' file. The 
+      the raw input or output, look at the ``Processor.swift'' file. The 
       {\tt Processor} class acts as a coordinator, receiving income audio, passing that
       to the detector and generating appropriate output TTL signals.
       \end{itemize}
@@ -1307,3 +1332,4 @@ detector is available under an open-source license {\em (Tentatively GPL, but we
 
 \end{document}
 
+s


### PR DESCRIPTION
Updated the MATLAB runtime passage to describe how to install and use the MATLAB detector. I included instructions for configuring the Arduino, as well as the standard audio output.

I also updated the repository with a license (the one requested by Jeff) and a README describing basic usage and linking to the other relevant repositories.
